### PR TITLE
Prevent duplicate history when loading with empty query

### DIFF
--- a/src/redux-query-sync.js
+++ b/src/redux-query-sync.js
@@ -102,9 +102,10 @@ function ReduxQuerySync({
             }
         })
         const newLocationSearchString = `?${locationParams}`
+        const oldLocationSearchString = location.search || '?'
 
         // Only update location if anything changed.
-        if (newLocationSearchString !== location.search) {
+        if (newLocationSearchString !== oldLocationSearchString) {
             // Update location (but prevent triggering a state update).
             ignoreLocationUpdate = true
             updateLocation({search: newLocationSearchString})


### PR DESCRIPTION
When a page is loaded without a query string and all parameters are set to their default value then newLocationSearchString will be `'?'` and location.search will be `''`. This ensures that the oldLocationSearchString, if ever empty, becomes the string `'?'`, preventing the history from being updated.

Tested in Chrome 59.