### PR TITLE
Allow user to pass a history object.

### DIFF
--- a/src/redux-query-sync.js
+++ b/src/redux-query-sync.js
@@ -30,10 +30,9 @@ function ReduxQuerySync({
     params,
     replaceState,
     initialTruth,
+    history = createHistory(),
 }) {
     const { dispatch } = store
-
-    const history = createHistory()
 
     // Two bits of state used to not respond to self-induced updates.
     let ignoreLocationUpdate = false


### PR DESCRIPTION
To work nicely together with e.g. react-router.

@dmitkataev, since you appear to have react-router set up already, would you mind trying if this fixes issue #9 for you?
