### PR TITLE
Feature/multiple values

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -82,6 +82,23 @@ ReduxQuerySync({
             // When state.pageNumber equals 1, the parameter p is hidden (and vice versa).
             defaultValue: 1,
         },
+        selection: {
+            selector: state => state.selection,
+            action: value => ({type: 'setSelection', payload: value}),
+
+            // Cast each value to a number
+            stringToValue: string => Number.parseInt(string) || 0,
+            // Convert to string
+            valueToString: value => `${value}`,
+
+            // Filter out invalid values
+            arrayToValue: array => array.filter(value => value),
+            // Filter negative values
+            valueToArray: value => value.filter(v => v > 0),
+
+            // When state.selection is empty array hide the parameter selection
+            defaultValue: []
+        },
     },
     initialTruth: 'location',
 
@@ -110,6 +127,9 @@ Sets up bidirectional synchronisation between a Redux store and window location 
 | [options.params[].defaultValue] | <code>\*</code> | The value corresponding to absence of the parameter. You may want this to equal the state's default/initial value. Default: `undefined`. |
 | [options.params[].valueToString] | <code>function</code> | Specifies how to cast the value to a string, to be used in the URL. Defaults to javascript's automatic string conversion. |
 | [options.params[].stringToValue] | <code>function</code> | The inverse of valueToString. Specifies how to parse the parameter's string value to your desired value type. Defaults to the identity function (i.e. you get the string as it is). |
+| [options.params[].multiple] | <code>boolean</code> | When true value support multiple values per key - i.e. `key=1&key=2`. The returned value from `selector` must be an array, and the provided value to `action` is also an array. The mappers `valueToString` and `stringToValue` are applied to each element of the array. Mappers `valueToArray` and `arrayToValue` can convert the whole array. |
+| [options.params[].valueToArray] | <code>function</code> | Converts the value to string array when `multiple` is true. |
+| [options.params[].arrayToValue] | <code>function</code> | Reverse convertion from string array to value. |
 | options.initialTruth | <code>string</code> | If set, indicates whose values to sync to the other, initially. Can be either `'location'` or `'store'`. If not set, the first of them that changes will set the other, which is not recommended. Usually you will want to use `location`. |
 | [options.replaceState] | <code>boolean</code> | If truthy, update location using `history.replaceState` instead of `history.pushState`, to not add entries to the browser history. Default: false |
 | [options.history] | <code>Object</code> | If you use the 'history' module, e.g. when using a router, pass your history object here in order to ensure all code uses the same instance. |

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "babel-preset-stage-1": "^6.24.1"
   },
   "dependencies": {
+    "array-equal": "^1.0.0",
     "history": "^4.6.3",
     "postinstall-build": "^3.0.1",
     "url-search-params": "0.10.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -49,6 +49,10 @@ arr-flatten@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/arr-flatten/-/arr-flatten-1.0.3.tgz#a274ed85ac08849b6bd7847c4580745dc51adfb1"
 
+array-equal@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/array-equal/-/array-equal-1.0.0.tgz#8c2a5ef2472fd9ea742b04c77a75093ba2757c93"
+
 array-unique@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.2.1.tgz#a1d97ccafcbc2625cc70fadceb36a50c58b01a53"


### PR DESCRIPTION
Support for multiple values per key.

New param options:
* `multiple` - specify if the parameter is array
* `valueToArray` - convert selector value to array
* `arrayToValue` - convert query array to value for action

Note: there is a catch that if the store value is not actually simple array the defaultValue check will not work. A solution is to return simple array from `selector`.

Ref #29 