### PR TITLE
Update method of importing from 'history'

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "babel-preset-stage-1": "^6.24.1"
   },
   "dependencies": {
-    "history": "^4.6.3",
+    "history": "^4.8.0",
     "postinstall-build": "^3.0.1",
     "url-search-params": "0.10.0"
   }

--- a/src/redux-query-sync.js
+++ b/src/redux-query-sync.js
@@ -1,4 +1,4 @@
-import createHistory from 'history/createBrowserHistory'
+import { createBrowserHistory as createHistory } from 'history';
 import URLSearchParams from 'url-search-params';
 
 /**


### PR DESCRIPTION
Starting with [`history`](https://github.com/ReactTraining/history) version [4.8.0](https://github.com/ReactTraining/history/releases/tag/v4.8.0-beta.0), the method of importing `createBrowserHistory` has changed from:

```javascript
import createHistory from 'history/createBrowserHistory';
```

to:

```javascript
import { createBrowserHistory }  from 'history';
```

In fact, if you keep using the original method, you'll get this message in the browser:

```
Warning: Please use `require("history").createBrowserHistory` instead of
`require("history/createBrowserHistory")`. Support for the latter will be removed in
the next major release.
```

This PR makes a simple one line change to address the deprecation.