### PR TITLE
Support history v5

### DIFF
--- a/src/redux-query-sync.js
+++ b/src/redux-query-sync.js
@@ -68,6 +68,11 @@ function ReduxQuerySync({
     }
 
     function handleLocationUpdate(location) {
+        // Support history v5
+        if (location.location != null) {
+            location = location.location;
+        }
+
         // Ignore the event if the location update was induced by ourselves.
         if (ignoreLocationUpdate) return
 

--- a/src/redux-query-sync.js
+++ b/src/redux-query-sync.js
@@ -69,7 +69,7 @@ function ReduxQuerySync({
 
     function handleLocationUpdate(location) {
         // Support history v5
-        if (location.location != null) {
+        if (location.location !== undefined) {
             location = location.location;
         }
 


### PR DESCRIPTION
Listener signature has changed from `(location, action) => {...}` to `({location, action}) => {...}`