### PR TITLE
Allow default to work for arrays and objects

### DIFF
--- a/src/redux-query-sync.js
+++ b/src/redux-query-sync.js
@@ -123,7 +123,7 @@ function ReduxQuerySync({
         Object.keys(params).forEach(param => {
             const { selector, defaultValue, valueToString = v => `${v}` } = params[param]
             const value = selector(state)
-            if (value === defaultValue) {
+            if (JSON.stringify(value) === JSON.stringify(defaultValue)) {
                 locationParams.delete(param)
             } else {
                 locationParams.set(param, valueToString(value))


### PR DESCRIPTION
Currently, the hiding of the default parameter only works for simple objects such as strings and integers. This allows it to work for complex objects. Thus allowing the user to store stringified dictionaries or arrays in location and still leverage the default.

Ie, `[3] === [3]`